### PR TITLE
add Forward_Adjoint as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Forward_Adjoint"]
+	path = Forward_Adjoint
+	url = ../../BIOPTIMOD/Forward_Adjoint

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,4 +18,6 @@ add_library(fabm_models_ogs OBJECT
            )
 
 add_dependencies(fabm_models_ogs fabm_base)
+add_subdirectory(Forward_Adjoint EXCLUDE_FROM_ALL)
+install(TARGETS adj EXPORT fabmConfig)
 target_link_libraries(fabm_models_ogs adj)


### PR DESCRIPTION
This is meant as a demonstration of how the "adj" dependency might be dealt with.

In this PR, [the underlying code](https://github.com/BIOPTIMOD/Forward_Adjoint) is added as git submodule, and then a few lines are added to the original `CMakeLists.txt` to ensure it is compiled as part of FABM+BFM. If combined with a recent enough FABM (2.0 or up), the adj library will be automatically linked in by host models that use cmake - no changes to higher level CMakeLists.txt files are then needed. This applies for instance to [GOTM](https://gotm.net).

Note that submodules add complexity to a git repository: for instance, users have to use `git clone --recurse-submodules <URL>` to get _all_ code (bfm and adj), and use `git pull --recurse-submodules` to keep all code up to date. It that turns out to be too much of a hassle, an alternative would be to include a "frozen" version of adj as subdirectory, instead of as submodule.