### PR TITLE
replace add_dependencies with target_link_libraries to support parallel ninja builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(fabm_models_ogs OBJECT
             PelagicCSYS.F90
            )
 
-add_dependencies(fabm_models_ogs fabm_base)
+target_link_libraries(fabm_models_ogs PRIVATE fabm_base)
 add_subdirectory(Forward_Adjoint EXCLUDE_FROM_ALL)
 install(TARGETS adj EXPORT fabmConfig)
 target_link_libraries(fabm_models_ogs adj)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ add_library(fabm_models_ogs OBJECT
 target_link_libraries(fabm_models_ogs PRIVATE fabm_base)
 add_subdirectory(Forward_Adjoint EXCLUDE_FROM_ALL)
 install(TARGETS adj EXPORT fabmConfig)
-target_link_libraries(fabm_models_ogs adj)
+target_link_libraries(fabm_models_ogs PRIVATE adj)
 include_directories(Forward_Adjoint/include)
 
 


### PR DESCRIPTION
This replaces cmake's `add_dependencies` with `target_link_libraries`. This is in line with [FABM 2.0 conventions](https://github.com/fabm-model/fabm/wiki/Developing-a-new-biogeochemical-model#adding-necessary-files) and required to support parallel builds with [ninja](https://ninja-build.org/). It prevents problems such as [this test failure](https://github.com/fabm-model/fabm-plus/actions/runs/8924225376/job/24510121335), which will likely affect BFM too when it is included in [fabm-plus](https://github.com/fabm-model/fabm-plus).

The change is compatible with all FABM versions; it just requires cmake 3.12, which was released [nearly 6 years ago](https://github.com/Kitware/CMake/tree/v3.12.0) and therefore widely available.